### PR TITLE
Fix latest_version field in cookbook information api endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
   <artifactId>nexus-repository-chef</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <inceptionYear>2018</inceptionYear>
   <packaging>bundle</packaging>
 

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/supermarket/CookbookInfoJsonModelBuilder.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/supermarket/CookbookInfoJsonModelBuilder.java
@@ -100,7 +100,7 @@ public class CookbookInfoJsonModelBuilder {
                 maintainer,
                 description,
                 CATEGORY,
-                latestVersion.toString(),
+                convertVersionToUrl(latestVersion),
                 externalUrl,
                 sourceUrl,
                 issuesUrl,


### PR DESCRIPTION
This field should give the full supermarket link to the latest version, and not just the version number.
