### PR TITLE
Fix search of metadata files during cookbook upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
   <artifactId>nexus-repository-chef</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
-  <version>0.0.4</version>
+  <version>0.0.6</version>
   <inceptionYear>2018</inceptionYear>
   <packaging>bundle</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
   <artifactId>nexus-repository-chef</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
-  <version>0.0.6</version>
+  <version>0.0.7</version>
   <inceptionYear>2018</inceptionYear>
   <packaging>bundle</packaging>
 

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/metadata/util/TgzParser.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/metadata/util/TgzParser.java
@@ -18,11 +18,13 @@ public class TgzParser {
 
     @Nullable
     public InputStream getFileFromInputStream(final InputStream is, String fileName) throws IOException {
+        // Match the sought filename only if it is in the root of the archive or one subfolder down
+        String fileNameRegex = "^[^/]*[/]*" + fileName + "$";
         try (GzipCompressorInputStream gzis = new GzipCompressorInputStream(is)) {
             try (TarArchiveInputStream tais = new TarArchiveInputStream(gzis)) {
                 ArchiveEntry currentEntry;
                 while ((currentEntry = tais.getNextEntry()) != null) {
-                    if (currentEntry.getName().toLowerCase().endsWith(fileName)) {
+                    if (currentEntry.getName().toLowerCase().matches(fileNameRegex)) {
                         log.info(String.format("Found %s file in archive: %s", fileName, currentEntry.getName()));
                         byte[] buf = new byte[(int) currentEntry.getSize()];
                         tais.read(buf, 0, buf.length);

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/metadata/util/TgzParser.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/metadata/util/TgzParser.java
@@ -10,6 +10,7 @@ import org.sonatype.goodies.common.*;
 import javax.annotation.*;
 import javax.inject.*;
 import java.io.*;
+import java.util.regex.Pattern;
 
 @Named
 @Singleton
@@ -19,7 +20,7 @@ public class TgzParser {
     @Nullable
     public InputStream getFileFromInputStream(final InputStream is, String fileName) throws IOException {
         // Match the sought filename only if it is in the root of the archive or one subfolder down
-        String fileNameRegex = "^(?:[^/]*/)?" + fileName.replaceAll("\\.", "\\\\.") + "$";
+        String fileNameRegex = "^(?:[^/]*/)?" + Pattern.quote(fileName) + "$";
         try (GzipCompressorInputStream gzis = new GzipCompressorInputStream(is)) {
             try (TarArchiveInputStream tais = new TarArchiveInputStream(gzis)) {
                 ArchiveEntry currentEntry;

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/metadata/util/TgzParser.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/metadata/util/TgzParser.java
@@ -19,7 +19,7 @@ public class TgzParser {
     @Nullable
     public InputStream getFileFromInputStream(final InputStream is, String fileName) throws IOException {
         // Match the sought filename only if it is in the root of the archive or one subfolder down
-        String fileNameRegex = "^[^/]*[/]*" + fileName + "$";
+        String fileNameRegex = "^(?:[^/]*/)?" + fileName.replaceAll("\\.", "\\\\.") + "$";
         try (GzipCompressorInputStream gzis = new GzipCompressorInputStream(is)) {
             try (TarArchiveInputStream tais = new TarArchiveInputStream(gzis)) {
                 ArchiveEntry currentEntry;


### PR DESCRIPTION
In rare cases a cookbook tarball can have additional metadata files belonging to another cookbook in their folder structure. We add a filter to just look for metadata files in either the root folder of the
cookbook or one level down.
