### PR TITLE
Allow setting a custom base url for supermarket responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
   <artifactId>nexus-repository-chef</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
-  <version>0.0.8</version>
+  <version>0.0.9</version>
   <inceptionYear>2018</inceptionYear>
   <packaging>bundle</packaging>
 

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/api/ChefApiRepositoryAdapter.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/api/ChefApiRepositoryAdapter.java
@@ -30,10 +30,16 @@ public class ChefApiRepositoryAdapter
                         name,
                         url,
                         online,
+                        createChefHostedRepositoryAttributes(repository),
                         getHostedStorageAttributes(repository),
                         getCleanupPolicyAttributes(repository),
                         getComponentAttributes(repository));
         }
         return null;
+    }
+
+    private ChefHostedRepositoryAttributes createChefHostedRepositoryAttributes(final Repository repository) {
+        String supermarketBaseUrl = repository.getConfiguration().attributes(ChefFormat.NAME).get("supermarketBaseUrl", String.class);
+        return new ChefHostedRepositoryAttributes(supermarketBaseUrl);
     }
 }

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/api/ChefHostedApiRepository.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/api/ChefHostedApiRepository.java
@@ -9,18 +9,31 @@ import org.sonatype.nexus.repository.rest.api.model.ComponentAttributes;
 import org.sonatype.nexus.repository.rest.api.model.HostedStorageAttributes;
 import org.sonatype.nexus.repository.rest.api.model.SimpleApiHostedRepository;
 
+import javax.validation.constraints.NotNull;
+
 @JsonIgnoreProperties(value = {"format", "type", "url"}, allowGetters = true)
 public class ChefHostedApiRepository
         extends SimpleApiHostedRepository {
+
+    @NotNull
+    protected final ChefHostedRepositoryAttributes chef;
+
     @JsonCreator
     public ChefHostedApiRepository(
             @JsonProperty("name") final String name,
             @JsonProperty("url") final String url,
             @JsonProperty("online") final Boolean online,
+            @JsonProperty("chef") final ChefHostedRepositoryAttributes chef,
             @JsonProperty("storage") final HostedStorageAttributes storage,
             @JsonProperty("cleanup") final CleanupPolicyAttributes cleanup,
             @JsonProperty("component") final ComponentAttributes component) {
         super(name, ChefFormat.NAME, url, online, storage, cleanup, component);
+        this.chef = chef;
     }
+
+    public ChefHostedRepositoryAttributes getChef() {
+        return chef;
+    }
+
 }
 

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/api/ChefHostedApiRepositoryRequest.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/api/ChefHostedApiRepositoryRequest.java
@@ -9,6 +9,9 @@ import org.sonatype.nexus.repository.rest.api.model.ComponentAttributes;
 import org.sonatype.nexus.repository.rest.api.model.HostedRepositoryApiRequest;
 import org.sonatype.nexus.repository.rest.api.model.HostedStorageAttributes;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 /*
  * Sonatype Nexus (TM) Open Source Version
  * Copyright (c) 2008-present Sonatype, Inc.
@@ -25,13 +28,24 @@ import org.sonatype.nexus.repository.rest.api.model.HostedStorageAttributes;
 public class ChefHostedApiRepositoryRequest
         extends HostedRepositoryApiRequest {
 
+    @NotNull
+    @Valid
+    protected final ChefHostedRepositoryAttributes chef;
+
     @JsonCreator
     public ChefHostedApiRepositoryRequest(
             @JsonProperty("name") final String name,
             @JsonProperty("online") final Boolean online,
+            @JsonProperty("chef") final ChefHostedRepositoryAttributes chef,
             @JsonProperty("storage") final HostedStorageAttributes storage,
             @JsonProperty("cleanup") final CleanupPolicyAttributes cleanup,
             @JsonProperty("component") final ComponentAttributes componentAttributes) {
         super(name, ChefFormat.NAME, online, storage, cleanup, componentAttributes);
+        this.chef = chef;
     }
+
+    public ChefHostedRepositoryAttributes getChef() {
+        return chef;
+    }
+
 }

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/api/ChefHostedRepositoryApiRequestToConfigurationConverter.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/api/ChefHostedRepositoryApiRequestToConfigurationConverter.java
@@ -10,6 +10,8 @@ public class ChefHostedRepositoryApiRequestToConfigurationConverter
         extends HostedRepositoryApiRequestToConfigurationConverter<ChefHostedApiRepositoryRequest> {
     @Override
     public Configuration convert(final ChefHostedApiRepositoryRequest request) {
-        return super.convert(request);
+        Configuration configuration = super.convert(request);
+        configuration.attributes("chef").set("supermarketBaseUrl", request.getChef().getSupermarketBaseUrl());
+        return configuration;
     }
 }

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/api/ChefHostedRepositoryAttributes.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/api/ChefHostedRepositoryAttributes.java
@@ -1,0 +1,20 @@
+package org.sonatype.nexus.repository.chef.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+public class ChefHostedRepositoryAttributes
+{
+    @ApiModelProperty(value = "Base url to use for Supermarket API responses. Leave blank to use hostname + repo name", example = "http://supermarket.internal")
+    protected final String supermarketBaseUrl;
+
+    @JsonCreator
+    public ChefHostedRepositoryAttributes(@JsonProperty("supermarketBaseUrl") final String supermarketBaseUrl) {
+        this.supermarketBaseUrl = supermarketBaseUrl;
+    }
+
+    public String getSupermarketBaseUrl() {
+        return supermarketBaseUrl;
+    }
+}

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/hosted/ChefHostedFacet.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/hosted/ChefHostedFacet.java
@@ -11,6 +11,9 @@ import java.io.IOException;
 @Facet.Exposed
 public interface ChefHostedFacet
         extends Facet {
+
+    String getSupermarketBaseUrl();
+
     void upload(Payload payload) throws IOException;
 
     @Nullable

--- a/src/main/java/org/sonatype/nexus/repository/chef/internal/hosted/ChefHostedFacetImpl.java
+++ b/src/main/java/org/sonatype/nexus/repository/chef/internal/hosted/ChefHostedFacetImpl.java
@@ -1,13 +1,17 @@
 package org.sonatype.nexus.repository.chef.internal.hosted;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.sonatype.nexus.repository.FacetSupport;
 import org.sonatype.nexus.repository.chef.internal.AssetKind;
+import org.sonatype.nexus.repository.config.Configuration;
+import org.sonatype.nexus.repository.config.ConfigurationFacet;
 import org.sonatype.nexus.repository.transaction.TransactionalStoreBlob;
 import org.sonatype.nexus.repository.view.Content;
 import org.sonatype.nexus.repository.view.Payload;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.validation.groups.Default;
 import java.io.IOException;
 
 @Named
@@ -15,6 +19,42 @@ public class ChefHostedFacetImpl extends FacetSupport implements ChefHostedFacet
 
     @Inject
     public ChefHostedFacetImpl() {
+    }
+
+    @VisibleForTesting
+    static final String CONFIG_KEY = "chef";
+
+    @VisibleForTesting
+    static class Config
+    {
+        public String supermarketBaseUrl;
+    }
+
+    private Config config;
+
+    @Override
+    protected void doValidate(final Configuration configuration) throws Exception {
+        facet(ConfigurationFacet.class).validateSection(
+                configuration,
+                CONFIG_KEY,
+                Config.class,
+                Default.class,
+                getRepository().getType().getValidationGroup());
+    }
+
+    @Override
+    protected void doConfigure(final Configuration configuration) throws Exception {
+        config = facet(ConfigurationFacet.class).readSection(configuration, CONFIG_KEY, Config.class);
+    }
+
+    @Override
+    protected void doDestroy() throws Exception {
+        config = null;
+    }
+
+    @Override
+    public String getSupermarketBaseUrl() {
+        return config.supermarketBaseUrl;
     }
 
     @Override

--- a/src/main/resources/static/rapture/NX/chef/app/PluginStrings.js
+++ b/src/main/resources/static/rapture/NX/chef/app/PluginStrings.js
@@ -25,7 +25,9 @@ Ext.define('NX.chef.app.PluginStrings', {
   ],
 
   keys: {
-    Repository_Facet_ChefFacet_Title: 'Chef Settings',
+    Repository_Facet_ChefSettings_Title: 'Chef Settings',
+    Repository_Facet_ChefSettings_SupermarketUrl_HelpText: 'Base url to use for Supermarket API responses (example: http://supermarket.internal). Leave blank to use Nexus hostname + repo name.',
+    Repository_Facet_ChefSettings_SupermarketUrl_FieldLabel: 'Base supermarket URL alias',
     SearchChef_Group: 'Chef Repositories',
     SearchChef_License_FieldLabel: 'License',
     SearchChef_Text: 'Chef',

--- a/src/main/resources/static/rapture/NX/chef/view/repository/recipe/ChefHosted.js
+++ b/src/main/resources/static/rapture/NX/chef/view/repository/recipe/ChefHosted.js
@@ -16,6 +16,7 @@ Ext.define('NX.chef.view.repository.recipe.ChefHosted', {
   extend: 'NX.coreui.view.repository.RepositorySettingsForm',
   alias: 'widget.nx-coreui-repository-chef-hosted',
   requires: [
+    'NX.coreui.view.repository.recipe.ChefSettings',
     'NX.coreui.view.repository.facet.StorageFacet',
     'NX.coreui.view.repository.facet.StorageFacetHosted',
     'NX.coreui.view.repository.facet.CleanupPolicyFacet'
@@ -28,6 +29,7 @@ Ext.define('NX.chef.view.repository.recipe.ChefHosted', {
     var me = this;
 
     me.items = [
+      {xtype: 'nx-chefui-repository-chef-chefsettings'},
       {xtype: 'nx-coreui-repository-storage-facet'},
       {xtype: 'nx-coreui-repository-storage-hosted-facet', writePolicy: 'ALLOW'},
       {xtype: 'nx-coreui-repository-cleanup-policy-facet'}

--- a/src/main/resources/static/rapture/NX/chef/view/repository/recipe/ChefSettings.js
+++ b/src/main/resources/static/rapture/NX/chef/view/repository/recipe/ChefSettings.js
@@ -1,0 +1,53 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2008-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Open Source Version is distributed with Sencha Ext JS pursuant to a FLOSS Exception agreed upon
+ * between Sonatype, Inc. and Sencha Inc. Sencha Ext JS is licensed under GPL v3 and cannot be redistributed as part of a
+ * closed source work.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+/**
+ * Configuration specific to chef repositories.
+ *
+ */
+Ext.define('NX.coreui.view.repository.recipe.ChefSettings', {
+    extend: 'Ext.form.FieldContainer',
+    alias: 'widget.nx-chefui-repository-chef-chefsettings',
+    requires: [
+        'NX.I18n'
+    ],
+    /**
+     * @override
+     */
+    initComponent: function() {
+        var me = this;
+
+        me.items = [
+            {
+                xtype: 'fieldset',
+                cls: 'nx-form-section',
+                title: NX.I18n.get('Repository_Facet_ChefSettings_Title'),
+                items: [
+                    {
+                        xtype:'textfield',
+                        name: 'attributes.chef.supermarketBaseUrl',
+                        fieldLabel: NX.I18n.get('Repository_Facet_ChefSettings_SupermarketUrl_FieldLabel'),
+                        helpText: NX.I18n.get('Repository_Facet_ChefSettings_SupermarketUrl_HelpText'),
+                        allowBlank: true
+                    }
+                ]
+            }
+        ];
+
+        me.callParent();
+    }
+
+});


### PR DESCRIPTION
This is useful when using an alias (such as http://supermarket.internal) for to reach the supermarket API and allows for example changing the nexus instance hosting the supermarket repo without having to change URLs is chef lock files that are dependent on the repo.
